### PR TITLE
Update `embedded-hal-async` to version `1.0.0-rc.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ rust-version = "1.65"
 
 [dependencies]
 accelerometer = "~0.12"
-embedded-hal-async = "0.2.0-alpha.1"
-num_enum = { version = "0.6.1", default-features = false }
+embedded-hal-async = "1.0.0-rc.1"
+num_enum = { version = "0.7", default-features = false }
 defmt = { version = "0.3", optional = true }
 
 [features]


### PR DESCRIPTION
Updates the `embedded-hal-async` to version `1.0.0-rc.1`, and additionally updates the `num_enum` dependency while I was in here.

(On a side note, we're using this package for our examples in [esp-hal](https://github.com/esp-rs/esp-hal), and I was one of the authors of the original blocking driver for this device, so if you'd like I'd be more than happy to take over maintaining this package! Feel free to message me on Matrix if you'd like to discuss this)